### PR TITLE
mark packages as public to publish them to npmjs

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-testing-library": "^4.2.0"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -12,6 +12,7 @@
   "author": "Artem Tamoian <artem.tamoian@veriff.com>",
   "license": "MIT",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -18,6 +18,7 @@
     "stylelint-declaration-strict-value": "^1.8.0"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }


### PR DESCRIPTION
Fixed npm package access configs and published manually all with version larger than our private ( from https://github.com/Veriff/code-style/pull/5 ).

- https://www.npmjs.com/package/@veriff/prettier-config
- https://www.npmjs.com/package/@veriff/stylelint-config
- https://www.npmjs.com/package/@veriff/eslint-config