### PR TITLE
FEAT: Add CI NPM release(/publish) when merged to master

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,11 +1,11 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-name: NPM Publish
+name: NPM Release
 
 on:
-  release:
-    types: [created]
+  push:
+    branches: [ master ]
 
 jobs:
   publish:
@@ -19,6 +19,6 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - name: NPM Publish
-        run: npm run npm_publish -- --yes
+        run: npm run release
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript": "^4.0.3"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }


### PR DESCRIPTION
Release uses semantic-release to release as needed.