### PR TITLE
feat(stylelint): allow 6px values

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -18,7 +18,7 @@ module.exports = {
     // Require following 4(four!)-point grid
     'plugin/8-point-grid': {
       base: 4,
-      allowlist: ['2px', '1px', '-1px', '-2px'],
+      allowlist: ['6px', '2px', '1px', '-1px', '-2px', '-6px'],
       ignorelist: ['width', 'height'],
     },
 


### PR DESCRIPTION
# Overview

The new design system supports `2px` and `6px` in addition to the normal 4 point grid. `2px` is already accounted for, this adds the missing `6px` and `-6px` to our Stylelint configuration.