### PR TITLE
chore: bump publish node to v18

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org/'
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
reason: https://github.com/Veriff/code-style/actions/runs/4478113217/jobs/7870472063